### PR TITLE
!HOTFIX: .js 확장자 생략 시 babel이 해당 모듈을 인식하지 못하는 문제

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -33,5 +33,6 @@ module.exports = {
     ],
     'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
     'import/no-unresolved': 'off', // for webpack path alias
+    'import/extensions': ['error', 'never', { js: 'always' }],
   },
 };

--- a/client/app/common/entry.js
+++ b/client/app/common/entry.js
@@ -1,11 +1,11 @@
-import './scripts/index';
+import './scripts/index.js';
 import './styles/index.scss';
 
 /**
  * @desc dev-server 에서 pug 변경에 대한 HMR 지원
  */
 const watchPugs = async () => {
-  const { default: pageNames } = await import('@/../page.config');
+  const { default: pageNames } = await import('@/../page.config.js');
 
   pageNames.forEach((pageName) => {
     import(`@pages/${pageName}/${pageName}.pug`);

--- a/client/app/common/scripts/index.js
+++ b/client/app/common/scripts/index.js
@@ -1,3 +1,3 @@
-import './_loadingBeforePageLoad';
+import './_loadingBeforePageLoad.js';
 
 console.log('Common entry has been loaded');

--- a/client/app/pages/home/entry.js
+++ b/client/app/pages/home/entry.js
@@ -1,5 +1,4 @@
+import '@templates/example-container/_entry';
+
 import './home.js';
 import './home.scss';
-
-// template dependencies
-import '@templates/example-container/_entry';

--- a/client/app/pages/home/entry.js
+++ b/client/app/pages/home/entry.js
@@ -1,4 +1,4 @@
-import './home';
+import './home.js';
 import './home.scss';
 
 // template dependencies

--- a/client/app/pages/login/entry.js
+++ b/client/app/pages/login/entry.js
@@ -1,5 +1,5 @@
-import '@/templates/auth-container/_entry';
+import '@templates/auth-container/_entry';
 import '@templates/footer/_entry';
 
-import './login';
+import './login.js';
 import './login.scss';

--- a/client/app/pages/suggested-feed/entry.js
+++ b/client/app/pages/suggested-feed/entry.js
@@ -1,4 +1,4 @@
-import './suggested-feed';
+import './suggested-feed/js';
 import './suggested-feed.scss';
 
 // template dependencies

--- a/client/app/pages/suggested-feed/entry.js
+++ b/client/app/pages/suggested-feed/entry.js
@@ -1,5 +1,4 @@
+import '@/templates/container/_entry';
+
 import './suggested-feed/js';
 import './suggested-feed.scss';
-
-// template dependencies
-import '@/templates/container/_entry';

--- a/client/app/pages/test-test/entry.js
+++ b/client/app/pages/test-test/entry.js
@@ -1,4 +1,4 @@
-import './test-test';
+import './test-test.js';
 import './test-test.scss';
 
 // template dependencies

--- a/client/app/pages/test-test/entry.js
+++ b/client/app/pages/test-test/entry.js
@@ -1,5 +1,4 @@
+import '@templates/container/_entry';
+
 import './test-test.js';
 import './test-test.scss';
-
-// template dependencies
-import '@templates/container/_entry';

--- a/client/app/templates/auth-container/_entry.js
+++ b/client/app/templates/auth-container/_entry.js
@@ -1,2 +1,2 @@
-import './auth-container';
+import './auth-container.js';
 import './auth-container.scss';

--- a/client/app/templates/container/_entry.js
+++ b/client/app/templates/container/_entry.js
@@ -1,3 +1,3 @@
-import './container';
+import './container.js';
 import './container.scss';
 import '@templates/footer/_entry';

--- a/client/app/templates/example-container/_entry.js
+++ b/client/app/templates/example-container/_entry.js
@@ -1,4 +1,4 @@
 // 이 entry는 웹팩 entry가 아닌, 이 템플릿을 사용하는 페이지의 entry.js 에서 import 되는 js 파일입니다.
 // 호출한 페이지의 entry.js 에 해당 템플릿에 대한 scss와 js 종속성을 포함시키는 역할을 합니다.
-import './example-container';
+import './example-container.js';
 import './example-container.scss';

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -8,8 +8,8 @@ const StylelintPlugin = require('stylelint-webpack-plugin');
 const ManifestPlugin = require('webpack-manifest-plugin');
 const CleanPlugin = require('clean-webpack-plugin');
 
-const parts = require('./webpack.parts');
-const pageNames = require('./page.config');
+const parts = require('./webpack.parts.js');
+const pageNames = require('./page.config.js');
 
 const pageNameToHtmlPathMap = pageNames.reduce((acc, page) => {
   const pageName = page !== 'home' ? page : 'index';


### PR DESCRIPTION
_issue raised by @pandora2948 in slack_

---
babel은 기본적으로 ECMAScript 와 연관성이 없어 
``` js
import myModule from './myModule';
```
위와 같이 `.js` 를 생략한 상태에서 트랜스파일링시 기본적으론 `.js` 확장자 자동 추가를 지원하지 않습니다. ([참고링크](https://stackoverflow.com/a/68007622)) 즉, 해당 모듈이 인식되지 않는 문제가 발생합니다. (플러그인 등을 잘 사용하면 자동 추가가 가능하긴 한 것 같지만 모르겠으니 생략)

헌데 eslint 설정에서 같은 확장자 파일끼리는 확장자를 생략하게 하는 규칙이 설정되어 있어, js 모듈 import 시에 확장자를 명시적으로 설정할 수 없었습니다.

위 eslint 설정을 수정하였습니다.

즉, 이제 이렇게 됩니다.
---
![image](https://user-images.githubusercontent.com/57123802/130105503-1098a3a7-b757-4a9b-8554-2ba28c90d47f.png)

1. JS path alias (절대 경로)를 사용하면 확장자 생략이 가능합니다. (Webpack resolve가 without extension을 지원합니다)
2. 상대 경로를 사용하면 확장자 생략이 안됩니다.

---
추가로, - closes #48 