### PR TITLE
feat: 백엔드 without extension url 적용으로 경로에서 .html 확장자 제거

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -13,10 +13,10 @@ const pageNames = require('./page.config.js');
 
 const pageNameToHtmlPathMap = pageNames.reduce((acc, page) => {
   const pageName = page !== 'home' ? page : 'index';
-  const htmlPath = `/${pageName}.html`;
+  const resourcePath = `/${pageName}`;
   const pugPageHrefVariable = page.replace(/-/g, '_');
 
-  acc[pugPageHrefVariable] = htmlPath;
+  acc[pugPageHrefVariable] = resourcePath;
   return acc;
 }, {});
 


### PR DESCRIPTION
이제 클라이언트 페이지 경로에서 .html 이 없어져요

_**#62 적용 후 merge**_