### PR TITLE
feat: 에러 핸들링 보완 및 로그 기능 추가, #62 누락사항 복구

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -10,6 +10,7 @@ import logger from 'koa-logger';
 
 import db from './models';
 import router from './routes';
+import saveErrorMessage from './lib/saveErrorMessage';
 
 if (process.env.NODE_ENV === 'production') {
   dotenv.config({ path: path.join(__dirname, '..', `.env.production`) });
@@ -43,5 +44,7 @@ app.use(serve(staticDir, serveOptions));
 
 app.use(router.routes());
 app.use(router.allowedMethods());
+
+app.on('error', saveErrorMessage);
 
 export default app;

--- a/server/src/config/config.ts
+++ b/server/src/config/config.ts
@@ -45,7 +45,7 @@ const currConfig = config[nodeEnv] || config.development;
 
 const isUndefinedValue = Object.values(currConfig).find((v) => v === undefined);
 if (isUndefinedValue) {
-  throw new Error('데이터베이스 필수 환경 설정 값이 누락되었습니다.');
+  throw new TypeError('데이터베이스 필수 환경 설정 값이 누락되었습니다.');
 }
 
 export default currConfig;

--- a/server/src/controllers/user.ts
+++ b/server/src/controllers/user.ts
@@ -26,12 +26,7 @@ export const verifyExistenceUsername = async (ctx: Context): Promise<void> => {
 export const createUser = async (ctx: Context): Promise<void> => {
   const createUserFields: CreateUserProps = ctx.request.body;
 
-  const createUserDto = new CreateUserDto();
-  Object.keys(createUserFields).forEach((fieldName) => {
-    type FieldName = keyof CreateUserProps;
-    createUserDto[fieldName as FieldName] = createUserFields[fieldName as FieldName];
-  });
-
+  const createUserDto = new CreateUserDto(createUserFields);
   const validationErrors: ValidationError[] = await validate(createUserDto);
   if (validationErrors.length > 0) {
     ctx.status = 400;

--- a/server/src/controllers/user.ts
+++ b/server/src/controllers/user.ts
@@ -16,7 +16,7 @@ export const verifyExistenceUsername = async (ctx: Context): Promise<void> => {
 
   if (exUser) {
     ctx.status = 409;
-    ctx.body = { message: '이미 존재하는 username 입니다.' };
+    ctx.body = { error: '이미 존재하는 username 입니다.' };
     return;
   }
   ctx.status = 202;

--- a/server/src/lib/createDatabase.ts
+++ b/server/src/lib/createDatabase.ts
@@ -4,7 +4,7 @@ import { writeFile, mkdir, readdirSync } from 'fs';
 import { execSync } from 'child_process';
 import { sync as rm } from 'del';
 
-import config from 'src/config/config';
+import config from '../config/config';
 
 const rootDir = path.join(__dirname, '..', '..'); // 🚩 High risk, because path is relative
 

--- a/server/src/lib/saveErrorMessage.ts
+++ b/server/src/lib/saveErrorMessage.ts
@@ -1,0 +1,32 @@
+import path from 'path';
+import { promises as fsPromise } from 'fs';
+
+export default async function saveErrorMessage(err: unknown): Promise<void> {
+  console.error(err);
+
+  const timeOffset = new Date().getTimezoneOffset() * 60000;
+  const now = new Date(Date.now() - timeOffset).toISOString();
+  const today = now.split('T')[0];
+
+  const logDir = path.join(__dirname, '..', 'log');
+  const logFile = path.join(logDir, `${today}.log`);
+
+  try {
+    await fsPromise.access(logDir);
+  } catch {
+    console.log('log/ 가 없으므로 새로 생성합니다.');
+    await fsPromise.mkdir(logDir);
+  }
+
+  console.log('서버 에러를 로그에 기록합니다.');
+
+  try {
+    if (err instanceof Error) {
+      await fsPromise.appendFile(logFile, `[${now}] --> ${err.message}\n\n`);
+      return;
+    }
+    console.error('"err" 인자가 "Error" 의 인스턴스가 아니라 로그에 기록할 수 없습니다.');
+  } catch (error) {
+    console.error(error);
+  }
+}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -5,6 +5,7 @@ import userRouter from './user';
 
 const router = new Router();
 
+// TODO: 프런트 측에 에러 페이지 요구
 router.use('(.*)', async (ctx, next) => {
   try {
     await next();
@@ -13,9 +14,9 @@ router.use('(.*)', async (ctx, next) => {
       ctx.body = '404 not found';
     }
   } catch (err) {
-    console.error(err);
     ctx.status = 500;
-    ctx.body = '500 server error';
+    ctx.body = { error: '500 server error' };
+    ctx.app.emit('error', err, ctx);
   }
 });
 

--- a/server/src/routes/sms.ts
+++ b/server/src/routes/sms.ts
@@ -1,9 +1,9 @@
 import Router from 'koa-router';
-import { sendSMSVerificationCode, checkSMSVerificationCode } from 'src/controllers/sms';
+import { sendSMSCode, checkSMSCode } from 'src/controllers/sms';
 
 const router = new Router();
 
-router.post('/', sendSMSVerificationCode);
-router.post('/match', checkSMSVerificationCode);
+router.post('/', sendSMSCode);
+router.post('/match', checkSMSCode);
 
 export default router;

--- a/server/typings/sms.dto.ts
+++ b/server/typings/sms.dto.ts
@@ -1,17 +1,12 @@
 import { IsMobilePhone, IsString } from 'class-validator';
+import type { SendSMSCodeProps } from 'typings/sms';
 
-export default class SendSMSVerificationCodeDto {
+export default class SendSMSCodeDto {
+  constructor({ phoneNumber }: SendSMSCodeProps) {
+    this.phoneNumber = phoneNumber;
+  }
+
   @IsString()
   @IsMobilePhone('ko-KR')
   phoneNumber!: string;
 }
-
-// export class CheckSMSVerificationCodeDto {
-//   @IsString()
-//   @IsMobilePhone('ko-KR')
-//   phoneNumber!: string;
-
-//   @IsNumberString()
-//   @Length(6, 6)
-//   code!: string;
-// }

--- a/server/typings/sms.ts
+++ b/server/typings/sms.ts
@@ -1,0 +1,3 @@
+export interface SendSMSCodeProps {
+  phoneNumber: string;
+}

--- a/server/typings/user.dto.ts
+++ b/server/typings/user.dto.ts
@@ -9,14 +9,14 @@ import {
 } from 'class-validator';
 import type { CreateUserProps, ReadUserProps } from 'typings/user';
 
-// export class VerifyExistenceUsernameDto {
-//   @IsString()
-//   @IsAlphanumeric()
-//   @IsLowercase()
-//   username!: string;
-// }
+export class CreateUserDto {
+  constructor({ phoneNumber, realname, username, password }: CreateUserProps) {
+    this.phoneNumber = phoneNumber;
+    this.realname = realname;
+    this.username = username;
+    this.password = password;
+  }
 
-export class CreateUserDto implements CreateUserProps {
   @IsMobilePhone('ko-KR')
   phoneNumber!: string;
 
@@ -37,7 +37,12 @@ export class CreateUserDto implements CreateUserProps {
   password!: string;
 }
 
-export class ReadUserDto implements ReadUserProps {
+export class ReadUserDto {
+  constructor({ id, password }: ReadUserProps) {
+    this.id = id;
+    this.password = password;
+  }
+
   @IsString()
   id!: string; // phone number || username
 


### PR DESCRIPTION
* 에러 핸들링 함수 추가 (서버 에러 발생 시 파일로 저장)
* 에러 발생 시 에러 메세지를 응답 json에 'error' 프로퍼티에 기록하도록 설정 (원래는 성공 응답과 같이 'message' 프로퍼티에 에러를 기록함)

* #62 에서 코멘트를 반영한 부분이 왠일인지 하나도 적용이 안되어있어 복구